### PR TITLE
v2.2.1 — In-place RBAC UX hardening

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rmq-vertical-scaler",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Helps operators configure, deploy, troubleshoot, and upgrade the RabbitMQ Vertical Scaler on Kubernetes. Provides skills that interview you about your workload, generate manifests, and diagnose why scaling isn't happening.",
   "author": {
     "name": "ferterahadi",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.1] - 2026-07-10
+
+### Added
+- **In-place RBAC preflight.** At startup the scaler runs a `SelfSubjectAccessReview` for `pods/resize` (patch) and `pods` (list) — testing *permission*, not just the API *capability* that discovery reports. `SCALE_MODE=auto` degrades to rolling with a warning that names the missing RBAC; explicit `SCALE_MODE=inplace` **fails fast** at startup with a message naming the exact verbs to grant, instead of a silent 403 at the first resize.
+
+### Fixed
+- **No stranded `OnDelete` override on missing RBAC.** In `auto` mode a resize rejected for lack of `pods/resize` RBAC (HTTP 403 Forbidden) is now treated like an infeasible resize — the scaler reverts the override and falls back to rolling — where before it hard-failed after already flipping the cluster to `OnDelete`. The startup preflight normally prevents this path from being reached at all.
+- Startup log now reads `Scale mode: inplace (pods/resize permitted)` — "permitted" (permission) rather than "supported" (capability).
+
+### Compatibility
+- No change to the Helm chart or `generate` RBAC output (both already grant `pods/resize`), env-var contract, or `SCALE_MODE` semantics. A hand-rolled deployment missing the `pods/resize` grant now surfaces the gap loudly instead of failing silently. Patching resource *limits* for Guaranteed-QoS pods (request ≤ limit) is out of scope here and deferred to a later release.
+
 ## [2.2.0] - 2026-07-05
 
 ### Added

--- a/charts/rmq-vertical-scaler/Chart.yaml
+++ b/charts/rmq-vertical-scaler/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rmq-vertical-scaler
 description: Vertically scales RabbitmqCluster CPU/memory based on queue depth and message rates.
 type: application
-version: 2.2.0
-appVersion: "2.2.0"
+version: 2.2.1
+appVersion: "2.2.1"
 home: https://github.com/ferterahadi/rmq-vertical-scaler
 sources:
   - https://github.com/ferterahadi/rmq-vertical-scaler

--- a/charts/rmq-vertical-scaler/README.md
+++ b/charts/rmq-vertical-scaler/README.md
@@ -17,8 +17,8 @@ helm install rvs charts/rmq-vertical-scaler \
 Or from a GitHub tag tarball (extract first — Helm needs the chart directory):
 
 ```bash
-curl -sL https://github.com/ferterahadi/rmq-vertical-scaler/archive/refs/tags/v2.2.0.tar.gz | tar xz
-helm install rvs rmq-vertical-scaler-2.2.0/charts/rmq-vertical-scaler \
+curl -sL https://github.com/ferterahadi/rmq-vertical-scaler/archive/refs/tags/v2.2.1.tar.gz | tar xz
+helm install rvs rmq-vertical-scaler-2.2.1/charts/rmq-vertical-scaler \
   --namespace production --create-namespace
 ```
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -25,8 +25,10 @@ type KubeClient interface {
 	ApplyPatch(ctx context.Context, cpu, memory string) error
 
 	// In-place resize (v2.2.0). EffectiveScaleMode resolves SCALE_MODE against
-	// cluster capability; the rest only run when it resolves to inplace.
-	EffectiveScaleMode() string
+	// cluster capability AND permission (v2.2.1); it errors only when an
+	// explicit SCALE_MODE=inplace lacks the required RBAC (fail fast). The rest
+	// only run when it resolves to inplace.
+	EffectiveScaleMode(ctx context.Context) (string, error)
 	EnsureOnDeleteStrategy(ctx context.Context) error
 	ResizePods(ctx context.Context, cpu, memory string) error
 	SetRollingUpdateStrategy(ctx context.Context) error
@@ -129,10 +131,19 @@ func (c *Controller) ApplyScale(ctx context.Context) error {
 // selects. Rolling is the v2.0.0 behaviour: one CR patch, the operator rolls
 // pods. In-place resizes the pods directly (no restart) and then patches the
 // CR too, keeping it the source of truth — under the OnDelete override that
-// patch does not roll anything. An Infeasible resize in auto mode reverts the
-// override and falls back to a rolling scale for this action.
+// patch does not roll anything.
+//
+// In auto mode a resize that comes back Infeasible (node can't fit it) or
+// Forbidden (missing pods/resize RBAC) reverts the OnDelete override and falls
+// back to a rolling scale for this action. The RBAC case is defence-in-depth:
+// the startup preflight (EffectiveScaleMode) normally resolves auto to rolling
+// before any resize is attempted, so OnDelete is never set without permission.
 func (c *Controller) applyResources(ctx context.Context, r config.Profile) error {
-	if c.scaleMode() != config.ScaleModeInPlace {
+	mode, err := c.scaleMode(ctx)
+	if err != nil {
+		return err
+	}
+	if mode != config.ScaleModeInPlace {
 		return c.kube.ApplyPatch(ctx, r.CPU, r.Memory)
 	}
 
@@ -140,8 +151,13 @@ func (c *Controller) applyResources(ctx context.Context, r config.Profile) error
 		return err
 	}
 	if err := c.kube.ResizePods(ctx, r.CPU, r.Memory); err != nil {
-		if c.cfg.ScaleMode == config.ScaleModeAuto && errors.Is(err, scaling.ErrResizeInfeasible) {
-			c.logger.Println("↩️  In-place resize infeasible on node; falling back to a rolling scale")
+		if c.cfg.ScaleMode == config.ScaleModeAuto &&
+			(errors.Is(err, scaling.ErrResizeInfeasible) || errors.Is(err, scaling.ErrResizePermission)) {
+			if errors.Is(err, scaling.ErrResizePermission) {
+				c.logger.Println("↩️  In-place resize forbidden (missing pods/resize RBAC); falling back to a rolling scale")
+			} else {
+				c.logger.Println("↩️  In-place resize infeasible on node; falling back to a rolling scale")
+			}
 			if serr := c.kube.SetRollingUpdateStrategy(ctx); serr != nil {
 				return serr
 			}
@@ -153,12 +169,18 @@ func (c *Controller) applyResources(ctx context.Context, r config.Profile) error
 }
 
 // scaleMode resolves the effective mode once and caches it for the loop's
-// lifetime (capability discovery doesn't change under a running process).
-func (c *Controller) scaleMode() string {
+// lifetime (capability + permission don't change under a running process). It
+// propagates the fail-fast error from an explicit SCALE_MODE=inplace that lacks
+// RBAC; Run resolves it eagerly so the process exits before the scaling loop.
+func (c *Controller) scaleMode(ctx context.Context) (string, error) {
 	if c.mode == "" {
-		c.mode = c.kube.EffectiveScaleMode()
+		m, err := c.kube.EffectiveScaleMode(ctx)
+		if err != nil {
+			return "", err
+		}
+		c.mode = m
 	}
-	return c.mode
+	return c.mode, nil
 }
 
 // logStability reproduces v1's per-branch stability log lines.
@@ -185,6 +207,13 @@ func (c *Controller) logStability(current, recommended string, state scaling.Sta
 // until ctx is cancelled (SIGTERM/SIGINT).
 func (c *Controller) Run(ctx context.Context) error {
 	c.logger.Println("🚀 RabbitMQ Vertical Scaler (Go)")
+
+	// Resolve the scale mode up front: an explicit SCALE_MODE=inplace without
+	// the required RBAC fails fast here, before we wait for RabbitMQ or touch
+	// the cluster (no stranded OnDelete override).
+	if _, err := c.scaleMode(ctx); err != nil {
+		return err
+	}
 
 	if err := c.metrics.WaitForRabbitMQ(ctx); err != nil {
 		if ctx.Err() != nil {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -15,15 +15,19 @@ import (
 )
 
 type fakeMetrics struct {
-	ov      metrics.Overview
-	ok      bool
-	queues  []metrics.Queue
-	waitErr error // returned by WaitForRabbitMQ when set
+	ov         metrics.Overview
+	ok         bool
+	queues     []metrics.Queue
+	waitErr    error // returned by WaitForRabbitMQ when set
+	waitCalled bool  // set when WaitForRabbitMQ is invoked
 }
 
 func (f *fakeMetrics) GetQueueMetrics(context.Context) (metrics.Overview, bool) { return f.ov, f.ok }
 func (f *fakeMetrics) GetDetailedQueues(context.Context) []metrics.Queue        { return f.queues }
-func (f *fakeMetrics) WaitForRabbitMQ(context.Context) error                    { return f.waitErr }
+func (f *fakeMetrics) WaitForRabbitMQ(context.Context) error {
+	f.waitCalled = true
+	return f.waitErr
+}
 
 type trackCall struct {
 	profile string
@@ -38,6 +42,7 @@ type fakeKube struct {
 	patchErr error // returned by ApplyPatch when set
 
 	mode       string      // returned by EffectiveScaleMode ("" -> rolling)
+	modeErr    error       // returned by EffectiveScaleMode when set (fail-fast)
 	resizes    [][2]string // ResizePods calls
 	resizeErr  error       // returned by ResizePods when set
 	ensures    []struct{}  // EnsureOnDeleteStrategy calls
@@ -58,11 +63,14 @@ func (f *fakeKube) ApplyPatch(_ context.Context, cpu, memory string) error {
 	f.patches = append(f.patches, [2]string{cpu, memory})
 	return nil
 }
-func (f *fakeKube) EffectiveScaleMode() string {
-	if f.mode == "" {
-		return config.ScaleModeRolling
+func (f *fakeKube) EffectiveScaleMode(context.Context) (string, error) {
+	if f.modeErr != nil {
+		return "", f.modeErr
 	}
-	return f.mode
+	if f.mode == "" {
+		return config.ScaleModeRolling, nil
+	}
+	return f.mode, nil
 }
 func (f *fakeKube) EnsureOnDeleteStrategy(context.Context) error {
 	if f.ensureErr != nil {
@@ -356,6 +364,56 @@ func TestApplyScaleInPlaceInfeasibleAutoFallsBackToRolling(t *testing.T) {
 	}
 	if len(k.tracking) != 1 {
 		t.Errorf("tracking = %v, want one reset after fallback scaling", k.tracking)
+	}
+}
+
+func TestApplyScaleInPlaceForbiddenAutoFallsBackToRolling(t *testing.T) {
+	// Defence-in-depth: a runtime RBAC 403 (missing pods/resize) in auto mode
+	// degrades to rolling and reverts the OnDelete override, just like Infeasible.
+	k := inPlaceKube(config.ScaleModeInPlace)
+	k.resizeErr = fmt.Errorf("pod rmq-server-0: %w", scaling.ErrResizePermission)
+	c := newCtrl(highLoad(), k, 1000)
+	c.cfg.ScaleMode = config.ScaleModeAuto
+
+	if err := c.ApplyScale(context.Background()); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(k.strategies) != 1 || k.strategies[0] != "RollingUpdate" {
+		t.Errorf("strategies = %v, want one RollingUpdate revert", k.strategies)
+	}
+	if len(k.patches) != 1 {
+		t.Errorf("patches = %v, want one CR patch (rolling fallback)", k.patches)
+	}
+	if len(k.tracking) != 1 {
+		t.Errorf("tracking = %v, want one reset after fallback scaling", k.tracking)
+	}
+}
+
+func TestApplyScaleModeResolutionErrorSwallowed(t *testing.T) {
+	// If mode resolution errors when reached lazily from applyResources (not
+	// pre-resolved by Run), the scaling loop logs and continues (returns nil).
+	k := inPlaceKube("")
+	k.modeErr = errors.New("SCALE_MODE=inplace lacks RBAC")
+	if err := newCtrl(highLoad(), k, 1000).ApplyScale(context.Background()); err != nil {
+		t.Fatalf("err = %v, want nil (error swallowed by the loop)", err)
+	}
+	if len(k.resizes) != 0 || len(k.patches) != 0 || len(k.tracking) != 0 {
+		t.Errorf("resizes/patches/tracking = %v/%v/%v, want none", k.resizes, k.patches, k.tracking)
+	}
+}
+
+func TestRunFailsFastWhenModeResolutionErrors(t *testing.T) {
+	// An explicit SCALE_MODE=inplace without RBAC surfaces as a mode-resolution
+	// error; Run must return it before waiting for RabbitMQ (no stranded state).
+	failFast := errors.New("SCALE_MODE=inplace but the scaler lacks RBAC: pods/resize (patch)")
+	k := &fakeKube{modeErr: failFast}
+	m := &fakeMetrics{}
+	err := newCtrl(m, k, 1000).Run(context.Background())
+	if !errors.Is(err, failFast) {
+		t.Fatalf("Run err = %v, want the fail-fast error", err)
+	}
+	if m.waitCalled {
+		t.Error("WaitForRabbitMQ was called; Run must fail fast before waiting")
 	}
 }
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ferterahadi/rmq-vertical-scaler/v2/internal/config"
 	"github.com/ferterahadi/rmq-vertical-scaler/v2/internal/scaling"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,26 +87,93 @@ func (c *Client) ResizeSupported() bool {
 	return false
 }
 
+// CheckResizePermissions asks the API server, via SelfSubjectAccessReview,
+// whether this pod's service account may perform the in-place resize
+// operations: patch on the pods/resize subresource and list on pods, both in
+// the scaler's namespace. It returns the human-readable RBAC descriptions of
+// any verbs that are denied (empty slice = fully permitted). This tests
+// *permission*, complementing ResizeSupported which only tests API capability.
+func (c *Client) CheckResizePermissions(ctx context.Context) ([]string, error) {
+	checks := []struct {
+		desc        string
+		resource    string
+		subresource string
+		verb        string
+	}{
+		{"pods/resize (patch)", "pods", "resize", "patch"},
+		{"pods (list)", "pods", "", "list"},
+	}
+	var missing []string
+	for _, chk := range checks {
+		review := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Namespace:   c.cfg.Namespace,
+					Verb:        chk.verb,
+					Group:       "",
+					Resource:    chk.resource,
+					Subresource: chk.subresource,
+				},
+			},
+		}
+		resp, err := c.core.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, review, metav1.CreateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("SelfSubjectAccessReview for %s: %w", chk.desc, err)
+		}
+		if !resp.Status.Allowed {
+			missing = append(missing, chk.desc)
+		}
+	}
+	return missing, nil
+}
+
 // EffectiveScaleMode resolves the configured SCALE_MODE against what the
-// cluster actually supports: auto picks inplace when pods/resize exists and
-// rolling otherwise; an explicit inplace is honoured even without support (the
-// resize patches will fail visibly) but logged.
-func (c *Client) EffectiveScaleMode() string {
+// cluster supports (API discovery) AND what this service account is permitted
+// to do (SelfSubjectAccessReview):
+//   - rolling: honoured as-is, no checks.
+//   - inplace (explicit): the operator asserted the capability, so a missing
+//     permission is a misconfiguration — return an error naming the exact RBAC
+//     so startup fails fast rather than 403-ing silently at the first resize.
+//   - auto: pick inplace only when pods/resize is both supported and permitted;
+//     otherwise degrade to rolling with a loud warning naming what's missing.
+//
+// It returns an error only in the explicit-inplace-denied case; all other
+// paths resolve to a usable mode.
+func (c *Client) EffectiveScaleMode(ctx context.Context) (string, error) {
 	switch c.cfg.ScaleMode {
 	case config.ScaleModeRolling:
-		return config.ScaleModeRolling
+		return config.ScaleModeRolling, nil
 	case config.ScaleModeInPlace:
 		if !c.ResizeSupported() {
 			c.logger.Println("⚠️  SCALE_MODE=inplace but the cluster does not advertise pods/resize; resizes will likely fail")
 		}
-		return config.ScaleModeInPlace
-	default: // auto
-		if c.ResizeSupported() {
-			c.logger.Println("🔧 Scale mode: inplace (pods/resize supported)")
-			return config.ScaleModeInPlace
+		missing, err := c.CheckResizePermissions(ctx)
+		if err != nil {
+			return "", fmt.Errorf("SCALE_MODE=inplace: could not verify in-place resize permissions: %w", err)
 		}
-		c.logger.Println("🔧 Scale mode: rolling (pods/resize not supported)")
-		return config.ScaleModeRolling
+		if len(missing) > 0 {
+			return "", fmt.Errorf("SCALE_MODE=inplace but the scaler's service account lacks required RBAC: %s — grant these verbs (see the chart's rbac.yaml) or set SCALE_MODE=auto to degrade to rolling",
+				strings.Join(missing, ", "))
+		}
+		c.logger.Println("🔧 Scale mode: inplace (pods/resize permitted)")
+		return config.ScaleModeInPlace, nil
+	default: // auto
+		if !c.ResizeSupported() {
+			c.logger.Println("🔧 Scale mode: rolling (pods/resize not supported)")
+			return config.ScaleModeRolling, nil
+		}
+		missing, err := c.CheckResizePermissions(ctx)
+		if err != nil {
+			c.logger.Printf("⚠️  Scale mode: rolling — could not verify pods/resize permissions (%v)", err)
+			return config.ScaleModeRolling, nil
+		}
+		if len(missing) > 0 {
+			c.logger.Printf("⚠️  Scale mode: rolling — pods/resize is supported but the scaler lacks RBAC: %s (grant these for in-place resize)",
+				strings.Join(missing, ", "))
+			return config.ScaleModeRolling, nil
+		}
+		c.logger.Println("🔧 Scale mode: inplace (pods/resize permitted)")
+		return config.ScaleModeInPlace, nil
 	}
 }
 
@@ -181,6 +249,12 @@ func (c *Client) ResizePods(ctx context.Context, cpu, memory string) error {
 		LabelSelector: "app.kubernetes.io/name=" + c.cfg.RMQServiceName,
 	})
 	if err != nil {
+		// A 403 here is missing `pods (list)` RBAC — tag it so auto mode can
+		// degrade to rolling instead of hard-failing (defence-in-depth behind
+		// the startup preflight).
+		if apierrors.IsForbidden(err) {
+			return fmt.Errorf("listing pods for %s: %w: %v", c.cfg.RMQServiceName, scaling.ErrResizePermission, err)
+		}
 		return fmt.Errorf("listing pods for %s: %w", c.cfg.RMQServiceName, err)
 	}
 	if len(pods.Items) == 0 {
@@ -211,9 +285,13 @@ func (c *Client) ResizePods(ctx context.Context, cpu, memory string) error {
 			// Newer API servers reject an unschedulable resize synchronously
 			// ("node didn't have enough allocatable resources") instead of the
 			// async kubelet Infeasible condition — same semantics, same error.
-			if apierrors.IsForbidden(err) && strings.Contains(err.Error(), "allocatable") {
+			switch {
+			case apierrors.IsForbidden(err) && strings.Contains(err.Error(), "allocatable"):
 				errs = append(errs, fmt.Errorf("pod %s: %w: %v", pod.Name, scaling.ErrResizeInfeasible, err))
-			} else {
+			case apierrors.IsForbidden(err):
+				// 403 without an allocatable verdict = missing pods/resize RBAC.
+				errs = append(errs, fmt.Errorf("pod %s: %w: %v", pod.Name, scaling.ErrResizePermission, err))
+			default:
 				errs = append(errs, fmt.Errorf("pod %s: %w", pod.Name, err))
 			}
 			continue

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ferterahadi/rmq-vertical-scaler/v2/internal/config"
 	"github.com/ferterahadi/rmq-vertical-scaler/v2/internal/scaling"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -202,6 +203,39 @@ func v1Resources(names ...string) *metav1.APIResourceList {
 	return rl
 }
 
+// ssarKey names a verb+resource(+subresource) the way withSSAR matches denials.
+func ssarKey(ra *authorizationv1.ResourceAttributes) string {
+	if ra.Subresource != "" {
+		return ra.Verb + ":" + ra.Resource + "/" + ra.Subresource
+	}
+	return ra.Verb + ":" + ra.Resource
+}
+
+// withSSAR installs a reactor answering SelfSubjectAccessReview creates: any
+// key in `denied` (e.g. "patch:pods/resize", "list:pods") is reported
+// not-allowed, everything else allowed. A non-nil errOut makes the review call
+// itself fail. Without this reactor the fake returns Allowed=false for every
+// review (zero value), i.e. fully denied.
+func withSSAR(core *corefake.Clientset, errOut error, denied ...string) *corefake.Clientset {
+	core.Fake.PrependReactor("create", "selfsubjectaccessreviews", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		if errOut != nil {
+			return true, nil, errOut
+		}
+		ssar := a.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		key := ssarKey(ssar.Spec.ResourceAttributes)
+		allowed := true
+		for _, d := range denied {
+			if d == key {
+				allowed = false
+			}
+		}
+		return true, &authorizationv1.SelfSubjectAccessReview{
+			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: allowed},
+		}, nil
+	})
+	return core
+}
+
 func TestResizeSupportedTrue(t *testing.T) {
 	core := withDiscovery(corefake.NewSimpleClientset(), v1Resources("pods", "pods/resize"))
 	c := newTestClient(t, core, newDynamic())
@@ -228,31 +262,100 @@ func TestResizeSupportedFalseOnDiscoveryError(t *testing.T) {
 
 func TestEffectiveScaleMode(t *testing.T) {
 	cases := []struct {
+		name      string
 		mode      string
 		supported bool
-		want      string
+		denied    []string // SSAR keys reported not-allowed
+		ssarErr   error    // review call itself fails
+		wantMode  string
+		wantErr   bool
 	}{
-		{config.ScaleModeRolling, true, config.ScaleModeRolling},
-		{config.ScaleModeRolling, false, config.ScaleModeRolling},
-		{config.ScaleModeInPlace, true, config.ScaleModeInPlace},
-		{config.ScaleModeInPlace, false, config.ScaleModeInPlace}, // forced, warn only
-		{config.ScaleModeAuto, true, config.ScaleModeInPlace},
-		{config.ScaleModeAuto, false, config.ScaleModeRolling},
+		// rolling is honoured as-is, no capability or permission check.
+		{"rolling supported", config.ScaleModeRolling, true, nil, nil, config.ScaleModeRolling, false},
+		{"rolling unsupported", config.ScaleModeRolling, false, nil, nil, config.ScaleModeRolling, false},
+
+		// explicit inplace: permitted -> inplace; denied -> fail fast (error).
+		{"inplace permitted", config.ScaleModeInPlace, true, nil, nil, config.ScaleModeInPlace, false},
+		{"inplace resize-denied fails fast", config.ScaleModeInPlace, true, []string{"patch:pods/resize"}, nil, "", true},
+		{"inplace list-denied fails fast", config.ScaleModeInPlace, true, []string{"list:pods"}, nil, "", true},
+		{"inplace ssar-error fails fast", config.ScaleModeInPlace, true, nil, errors.New("ssar boom"), "", true},
+		// forced inplace without discovery still checks permission (warn on capability).
+		{"inplace unsupported but permitted", config.ScaleModeInPlace, false, nil, nil, config.ScaleModeInPlace, false},
+
+		// auto: inplace only when supported AND permitted; otherwise degrade.
+		{"auto supported+permitted", config.ScaleModeAuto, true, nil, nil, config.ScaleModeInPlace, false},
+		{"auto supported+denied degrades", config.ScaleModeAuto, true, []string{"patch:pods/resize"}, nil, config.ScaleModeRolling, false},
+		{"auto supported+ssar-error degrades", config.ScaleModeAuto, true, nil, errors.New("ssar boom"), config.ScaleModeRolling, false},
+		{"auto unsupported degrades", config.ScaleModeAuto, false, nil, nil, config.ScaleModeRolling, false},
 	}
 	for _, tc := range cases {
-		core := corefake.NewSimpleClientset()
-		if tc.supported {
-			withDiscovery(core, v1Resources("pods", "pods/resize"))
-		} else {
-			withDiscovery(core, v1Resources("pods"))
-		}
-		cfg := testConfig()
-		cfg.ScaleMode = tc.mode
-		c := newClient(cfg, core, newDynamic(), log.New(io.Discard, "", 0))
-		if got := c.EffectiveScaleMode(); got != tc.want {
-			t.Errorf("mode=%s supported=%v: EffectiveScaleMode = %q, want %q",
-				tc.mode, tc.supported, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			core := corefake.NewSimpleClientset()
+			if tc.supported {
+				withDiscovery(core, v1Resources("pods", "pods/resize"))
+			} else {
+				withDiscovery(core, v1Resources("pods"))
+			}
+			withSSAR(core, tc.ssarErr, tc.denied...)
+			cfg := testConfig()
+			cfg.ScaleMode = tc.mode
+			c := newClient(cfg, core, newDynamic(), log.New(io.Discard, "", 0))
+
+			got, err := c.EffectiveScaleMode(context.Background())
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("EffectiveScaleMode err = nil, want fail-fast error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("EffectiveScaleMode err = %v, want nil", err)
+			}
+			if got != tc.wantMode {
+				t.Errorf("EffectiveScaleMode = %q, want %q", got, tc.wantMode)
+			}
+		})
+	}
+}
+
+func TestCheckResizePermissions(t *testing.T) {
+	cases := []struct {
+		name        string
+		denied      []string
+		ssarErr     error
+		wantMissing []string
+		wantErr     bool
+	}{
+		{"all permitted", nil, nil, nil, false},
+		{"resize denied", []string{"patch:pods/resize"}, nil, []string{"pods/resize (patch)"}, false},
+		{"list denied", []string{"list:pods"}, nil, []string{"pods (list)"}, false},
+		{"both denied", []string{"patch:pods/resize", "list:pods"}, nil, []string{"pods/resize (patch)", "pods (list)"}, false},
+		{"ssar error", nil, errors.New("boom"), nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			core := withSSAR(corefake.NewSimpleClientset(), tc.ssarErr, tc.denied...)
+			c := newTestClient(t, core, newDynamic())
+
+			missing, err := c.CheckResizePermissions(context.Background())
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("CheckResizePermissions err = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CheckResizePermissions err = %v, want nil", err)
+			}
+			if len(missing) != len(tc.wantMissing) {
+				t.Fatalf("missing = %v, want %v", missing, tc.wantMissing)
+			}
+			for i, m := range tc.wantMissing {
+				if missing[i] != m {
+					t.Errorf("missing[%d] = %q, want %q", i, missing[i], m)
+				}
+			}
+		})
 	}
 }
 
@@ -495,8 +598,9 @@ func TestResizePodsSynchronousAllocatableRejectionIsInfeasible(t *testing.T) {
 	}
 }
 
-func TestResizePodsOtherForbiddenIsNotInfeasible(t *testing.T) {
-	// RBAC denial is also Forbidden but must NOT trigger the rolling fallback.
+func TestResizePodsForbiddenIsPermissionError(t *testing.T) {
+	// RBAC denial is also Forbidden but must NOT be Infeasible — it is tagged
+	// ErrResizePermission so auto mode degrades to rolling (defence-in-depth).
 	core := corefake.NewSimpleClientset(rmqPod("rmq-server-0", "rmq", "330m", "1Gi"))
 	core.Fake.PrependReactor("patch", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewForbidden(
@@ -506,7 +610,26 @@ func TestResizePodsOtherForbiddenIsNotInfeasible(t *testing.T) {
 	c := newTestClient(t, core, newDynamic())
 
 	err := c.ResizePods(context.Background(), "200m", "2Gi")
-	if err == nil || errors.Is(err, scaling.ErrResizeInfeasible) {
-		t.Errorf("err = %v, want a non-infeasible error for RBAC denial", err)
+	if !errors.Is(err, scaling.ErrResizePermission) {
+		t.Errorf("err = %v, want ErrResizePermission for RBAC denial", err)
+	}
+	if errors.Is(err, scaling.ErrResizeInfeasible) {
+		t.Errorf("err = %v, must not be ErrResizeInfeasible for RBAC denial", err)
+	}
+}
+
+func TestResizePodsListForbiddenIsPermissionError(t *testing.T) {
+	// Missing `pods (list)` RBAC surfaces before any patch — also tagged.
+	core := corefake.NewSimpleClientset(rmqPod("rmq-server-0", "rmq", "330m", "1Gi"))
+	core.Fake.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "pods"}, "",
+			errors.New(`user "system:serviceaccount:default:scaler" cannot list resource "pods"`))
+	})
+	c := newTestClient(t, core, newDynamic())
+
+	err := c.ResizePods(context.Background(), "200m", "2Gi")
+	if !errors.Is(err, scaling.ErrResizePermission) {
+		t.Errorf("err = %v, want ErrResizePermission for forbidden list", err)
 	}
 }

--- a/internal/scaling/scaling.go
+++ b/internal/scaling/scaling.go
@@ -31,6 +31,14 @@ var ErrNoMetrics = errors.New("connection error: unable to fetch metrics")
 // when it sees this.
 var ErrResizeInfeasible = errors.New("in-place resize infeasible on node")
 
+// ErrResizePermission marks an in-place resize (or its pod list) rejected for
+// lack of RBAC — a 403 Forbidden that is NOT an allocatable/feasibility verdict.
+// Like ErrResizeInfeasible it lives here so the controller can match it with
+// errors.Is without a client-go dependency. Auto mode degrades to a rolling
+// scale when it sees this (defence-in-depth; the startup preflight normally
+// resolves to rolling before any resize is attempted).
+var ErrResizePermission = errors.New("in-place resize forbidden: missing pods/resize RBAC")
+
 // CalculateScaleProfile derives metrics from the RabbitMQ payloads and selects
 // the target profile. overviewOK is false when the overview fetch failed (v1's
 // empty `{}`); like v1, an empty queue list is also treated as a skip.

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -8,6 +8,9 @@
 #   2. scale-down MEDIUM -> LOW in place (memory decrease, requests only)
 #   3. self-heal  deleted pod comes back at the current profile's size
 #   4. infeasible oversized profile falls back to a rolling scale (auto mode)
+#   5. rbac      missing pods/resize permission — auto degrades to rolling with
+#                a warning; explicit SCALE_MODE=inplace fails fast at startup
+#                (v2.2.1 preflight)
 #
 # Usage: tests/e2e/run.sh [--keep]   (--keep skips cluster teardown)
 set -euo pipefail
@@ -63,7 +66,7 @@ pods_cpu_is() { # $1 cpu — every server pod at this request
   done
 }
 
-echo "=== [0/6] kind cluster + operator + images ==="
+echo "=== [0/7] kind cluster + operator + images ==="
 if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER"; then
   kind create cluster --name "$CLUSTER" --wait 120s
 fi
@@ -85,13 +88,13 @@ wait_for 300 "cluster operator ready" \
 kind load docker-image rmq-vertical-scaler:e2e --name "$CLUSTER" > /dev/null
 note "scaler image built + loaded"
 
-echo "=== [1/6] RabbitMQ cluster (3 nodes) ==="
+echo "=== [1/7] RabbitMQ cluster (3 nodes) ==="
 kubectl apply -f "$DIR/rabbitmq-small.yaml" > /dev/null
 wait_for 600 "RabbitmqCluster AllReplicasReady" \
   kubectl wait rabbitmqclusters.rabbitmq.com/rabbitmq -n "$NS" --for=condition=AllReplicasReady --timeout=5s
 assert_requests 100m 300Mi "baseline"
 
-echo "=== [2/6] scaler (helm) ==="
+echo "=== [2/7] scaler (helm) ==="
 helm upgrade --install rmq-scaler "$ROOT/charts/rmq-vertical-scaler" -n "$NS" -f "$DIR/values.yaml" > /dev/null
 wait_for 120 "scaler deployment ready" \
   kubectl wait deploy/rmq-vertical-scaler -n "$NS" --for=condition=Available --timeout=5s
@@ -99,7 +102,7 @@ wait_for 120 "scaler deployment ready" \
 UIDS_BEFORE=$(snapshot_uids)
 RESTARTS_BEFORE=$(snapshot_restarts)
 
-echo "=== [3/6] scale-up LOW -> MEDIUM (in place) ==="
+echo "=== [3/7] scale-up LOW -> MEDIUM (in place) ==="
 kubectl apply -f "$DIR/load.yaml" > /dev/null
 wait_for 120 "consumer connected" \
   kubectl wait deploy/e2e-consumer -n "$NS" --for=condition=Available --timeout=5s
@@ -133,7 +136,7 @@ fi
 CONSUMER_RESTARTS=$(kubectl get pods -n "$NS" -l app=e2e-consumer -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
 [ "$CONSUMER_RESTARTS" = "0" ] && ok "consumer connection uninterrupted" || bad "consumer restarted $CONSUMER_RESTARTS times"
 
-echo "=== [4/6] scale-down MEDIUM -> LOW (in place, memory decrease) ==="
+echo "=== [4/7] scale-down MEDIUM -> LOW (in place, memory decrease) ==="
 kubectl delete deploy e2e-producer -n "$NS" > /dev/null
 # Purging while the producer pod is still terminating repopulates the queue.
 kubectl wait --for=delete pod -l app=e2e-producer -n "$NS" --timeout=120s > /dev/null 2>&1 || true
@@ -150,14 +153,14 @@ assert_requests 100m 300Mi "scale-down"
 [ "$(snapshot_uids)" = "$UIDS_BEFORE" ] && ok "scale-down: pod UIDs unchanged (memory decrease in place)" || bad "scale-down: pods were recreated"
 [ "$(snapshot_restarts)" = "$RESTARTS_BEFORE" ] && ok "scale-down: restartCount unchanged" || bad "scale-down: containers restarted"
 
-echo "=== [5/6] self-heal: deleted pod returns at current profile ==="
+echo "=== [5/7] self-heal: deleted pod returns at current profile ==="
 kubectl delete pod rabbitmq-server-1 -n "$NS" > /dev/null
 wait_for 300 "rabbitmq-server-1 ready again" \
   kubectl wait pod/rabbitmq-server-1 -n "$NS" --for=condition=Ready --timeout=5s
 HEAL_CPU=$(pod_field pod/rabbitmq-server-1 '{.spec.containers[?(@.name=="rabbitmq")].resources.requests.cpu}')
 [ "$HEAL_CPU" = "100m" ] && ok "self-heal: recreated pod at current profile (100m)" || bad "self-heal: recreated pod at $HEAL_CPU"
 
-echo "=== [6/6] infeasible resize falls back to rolling (auto mode) ==="
+echo "=== [6/7] infeasible resize falls back to rolling (auto mode) ==="
 # A MEDIUM profile larger than the node can ever fit: the kubelet marks the
 # resize Infeasible and auto mode must revert to a rolling scale. The rolling
 # attempt itself can never complete (nothing can fit 12Gi here) — the point
@@ -177,6 +180,73 @@ fi
 # sane profile and remove the load so the scaler settles back to LOW.
 kubectl set env deploy/rmq-vertical-scaler -n "$NS" PROFILE_MEDIUM_MEMORY- > /dev/null
 kubectl delete -f "$DIR/load.yaml" --ignore-not-found > /dev/null 2>&1 || true
+
+echo "=== [7/7] rbac preflight: missing pods/resize (v2.2.1) ==="
+# Simulate a hand-rolled deployment that forgot the pods/resize grant: strip
+# the resize rule from the scaler's Role, keeping everything else it needs.
+# (The Helm chart grants it; this proves the scaler no longer 403s silently.)
+ROLE=$(kubectl get role -n "$NS" -l app.kubernetes.io/name=rmq-vertical-scaler -o name | head -1)
+if [ -z "$ROLE" ]; then
+  bad "rbac: could not find the scaler Role"
+else
+  # Rewrite rules to the chart's set minus pods/resize (deterministic).
+  kubectl patch "$ROLE" -n "$NS" --type=json -p '[{"op":"replace","path":"/rules","value":[
+      {"apiGroups":["rabbitmq.com"],"resources":["rabbitmqclusters"],"verbs":["get","patch","update"]},
+      {"apiGroups":[""],"resources":["secrets"],"verbs":["get"]},
+      {"apiGroups":[""],"resources":["configmaps"],"verbs":["get","create","update","patch"]},
+      {"apiGroups":[""],"resources":["pods"],"verbs":["get","list"]}
+    ]}]' > /dev/null
+  note "stripped pods/resize from $ROLE"
+
+  # 5a. auto mode: preflight should degrade to rolling with a naming warning.
+  kubectl set env deploy/rmq-vertical-scaler -n "$NS" SCALE_MODE=auto > /dev/null
+  kubectl rollout restart deploy/rmq-vertical-scaler -n "$NS" > /dev/null
+  kubectl rollout status deploy/rmq-vertical-scaler -n "$NS" --timeout=90s > /dev/null 2>&1 || true
+  if wait_for 90 "auto degrade log" \
+    sh -c "kubectl logs deploy/rmq-vertical-scaler -n $NS --tail=-1 | grep -Eq 'Scale mode: rolling|lacks RBAC'"; then
+    LOGS=$(kubectl logs deploy/rmq-vertical-scaler -n "$NS" --tail=-1)
+    echo "$LOGS" | grep -q "pods/resize" && ok "auto: degraded to rolling, warning names pods/resize" \
+      || bad "auto: degraded but warning did not name pods/resize"
+  else
+    bad "auto: no rolling-degrade warning when pods/resize is missing"
+  fi
+
+  # 5b. explicit inplace: preflight should fail fast — the container exits
+  # non-zero at startup and crash-loops. We assert on the log message plus a
+  # climbing restartCount, NOT deployment Availability or rollout status: the
+  # scaler has no readiness probe, so during the brief "Running" window before
+  # os.Exit(1) the pod is counted Ready and the rollout can report complete.
+  # The crash-loop (restartCount >= 1) is the reliable proof it actually exited.
+  # True once any scaler pod's container has restarted at least once — the
+  # crash-loop that proves the process exited non-zero (wait_for calls it like
+  # pods_cpu_is above).
+  scaler_crashed() {
+    local r
+    r=$(kubectl get pods -n "$NS" -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.containerStatuses[0].restartCount}{"\n"}{end}' 2>/dev/null \
+        | awk '/^rmq-vertical-scaler-/ {print $2}' | sort -rn | head -1)
+    [ "${r:-0}" -ge 1 ]
+  }
+  kubectl set env deploy/rmq-vertical-scaler -n "$NS" SCALE_MODE=inplace > /dev/null
+  kubectl rollout restart deploy/rmq-vertical-scaler -n "$NS" > /dev/null
+  if wait_for 90 "inplace fail-fast log" \
+    sh -c "kubectl logs deploy/rmq-vertical-scaler -n $NS --tail=-1 --all-containers 2>/dev/null | grep -q 'lacks required RBAC'"; then
+    if wait_for 90 "scaler crash-loop (restartCount >= 1)" scaler_crashed; then
+      ok "inplace: failed fast with RBAC message and crash-looped (no silent 403)"
+    else
+      bad "inplace: logged the RBAC error but did not exit/restart (should fail fast)"
+    fi
+  else
+    bad "inplace: did not surface the fail-fast RBAC message"
+  fi
+
+  # Restore RBAC + auto mode so a --keep cluster is left healthy. Best-effort:
+  # kubectl patch/set take server-side-apply field ownership, so helm's re-apply
+  # can conflict — never let cleanup fail the suite (the cluster is torn down
+  # next anyway unless --keep).
+  kubectl set env deploy/rmq-vertical-scaler -n "$NS" SCALE_MODE- > /dev/null 2>&1 || true
+  helm upgrade --install rmq-scaler "$ROOT/charts/rmq-vertical-scaler" -n "$NS" \
+    -f "$DIR/values.yaml" --force > /dev/null 2>&1 || note "rbac restore skipped (SSA conflict; cluster torn down next)"
+fi
 
 echo
 echo "=== RESULT: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
# v2.2.1 — In-place RBAC UX hardening

## Why
v2.2.0 added in-place pod resize (`SCALE_MODE=auto|inplace|rolling`) but the scaler only *consumes* the `pods/resize` RBAC — it never checks it. The Helm chart and `generate` include that RBAC automatically, but a **hand-rolled deployment** that omits it got a poor, silent failure: startup logged `inplace (pods/resize supported)` and then 403'd at the first resize — after the RabbitmqCluster had already been flipped to `OnDelete`. Surfaced during a live mighty-cns upgrade (GKE Autopilot, K8s 1.35, 2.0.0→2.2.0) using hand-rolled manifests.

## What changed
1. **Startup preflight** — `SelfSubjectAccessReview` on `pods/resize` (patch) + `pods` (list). `auto` degrades to rolling with a warning naming the missing RBAC; explicit `inplace` **fails fast** naming the exact verbs. Tests *permission*; the old `ResizeSupported()` only tested API *capability*.
2. **Graceful 403 at runtime** — a Forbidden on resize/list is now tagged `ErrResizePermission` and, in `auto`, degrades to rolling (reverting `OnDelete`) like an infeasible resize. Defence-in-depth behind the preflight.
3. **Log wording** — `inplace (pods/resize permitted)` (permission), not "supported" (capability).

**Out of scope (deferred):** patching resource *limits* for Guaranteed-QoS / tight-limit pods (request ≤ limit) — a later release. RBAC UX hardening only.

**No breaking change:** chart + \`generate\` RBAC output is byte-for-byte unchanged (both already grant \`pods/resize\`); \`SCALE_MODE\` semantics and env-var contract unchanged. Patch bump 2.2.0→2.2.1.

## Go conventions (notes for JS eyes)
- **Sentinel errors + \`errors.Is\`.** \`ErrResizePermission\`/\`ErrResizeInfeasible\` are package-level \`error\` values used as typed signals — like a named error class you \`instanceof\`-check. \`errors.Is(err, ErrX)\` walks a wrapped-error chain rather than comparing strings.
- **\`%w\` wrapping.** \`fmt.Errorf("...: %w", err)\` returns a new error that still *contains* the original — like \`new Error(msg, { cause: err })\`. \`%w\` (not \`%v\`) is what lets \`errors.Is\` see through it, so the k8s layer wraps a raw 403 as \`ErrResizePermission\` and the controller matches it without importing client-go.
- **Consumer-side interface.** The controller defines its own small \`KubeClient\` interface; Go interfaces are satisfied implicitly, so the controller stays testable with a fake and free of any Kubernetes dependency — why the sentinel lives in \`scaling\`, not \`k8s\`.
- **\`SelfSubjectAccessReview\`** is the standard "can I do X?" API — POST a spec (verb/resource/namespace), read back \`Status.Allowed\`. One call per verb; denials aggregated into a human-readable list.
- **Eager vs lazy resolve.** \`Run\` resolves the scale mode once up front so an explicit-inplace RBAC failure exits the process *before* it waits for RabbitMQ or touches the cluster (no half-applied state).

## Tests
- Unit (\`go test ./...\`, green): SSAR preflight (permitted / resize-denied / list-denied / SSAR-error), mode resolution outcomes (auto-degrade, inplace-fail-fast, permitted), runtime 403→rolling+OnDelete-revert, fail-fast-before-wait. New branches at 100%; controller back to 100%, k8s 86.7%→89.2% (remainder is pre-existing in-cluster/marshal guards).
- E2E (\`tests/e2e/run.sh\`, kind K8s v1.36): **18 passed, 0 failed**, including the new \`[7/7]\` RBAC scenario — auto degrades to rolling naming pods/resize; explicit inplace exits non-zero with the fail-fast RBAC message and crash-loops.

## Test plan
- [x] Unit tests (\`go test ./...\`) — all pass
- [x] E2E tests (\`tests/e2e/run.sh\`, kind) — 18 passed, 0 failed